### PR TITLE
Various improvements to JSON handling and output format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ dist/
 build/
 .idea/
 
+# Specific files
+/aether-ant-tasks-uber.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,62 +1,8 @@
-FROM debian:8
+FROM tomcat:8-jre8
 
-
-RUN apt-get update &&  apt-get install -y --no-install-recommends \
-    jflex                       \
-    ant                         \
-    ant-optional                \
-    openjdk-7-jdk               \
-    texlive-latex-extra         \
-    texlive-fonts-recommended
-
-
-### Install tomcat ###
-RUN apt-get install -y wget
-# Put the newest version of tomcat, can be found:  https://downloads.apache.org/tomcat/tomcat-8/
-ENV TOMCAT_VERSION=8.5.75 
-RUN wget https://downloads.apache.org/tomcat/tomcat-8/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz
-RUN mkdir /opt/tomcat
-RUN tar xf apache-tomcat-${TOMCAT_VERSION}.tar.gz -C /opt/tomcat
-RUN cd /opt/tomcat && mv apache-tomcat-${TOMCAT_VERSION} tomcat
-
-ENV JAVA_TOOL_OPTIONS "-Dfile.encoding=UTF8"
-ENV CATALINA_HOME=/opt/tomcat/tomcat
-ENV CATALINA_BASE=/opt/tomcat/tomcat
-ENV JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
-
-
-### build IceNLP COre ###
-RUN apt-get install -y git
-RUN cd / && git clone https://github.com/sverrirab/icenlp.git
-WORKDIR /icenlp
-
-WORKDIR /icenlp/core/flex/icetagger
-RUN ./compileRules.sh
-
-WORKDIR /icenlp/core/flex/iceparser
-RUN ./flexAll.sh
-
-WORKDIR /icenlp/core
-RUN ant
-
-
-# install org.simple.json
-RUN cd $CATALINA_HOME/lib && wget https://repo1.maven.org/maven2/org/json/json/20210307/json-20210307.jar
-
-### build INLP-web ##
-
-#RUN rm -rf $CATALINA_HOME/webapps/ROOT/*
-#ADD . $CATALINA_HOME/webapps/ROOT/
-
-RUN cd $CATALINA_HOME/webapps/ROOT && rm * -r
-
-WORKDIR /icenlp-web
-COPY ./ .
-RUN cp /icenlp/core/dist/IceNLPCore.jar /icenlp-web/lib/
-
-RUN ant
-RUN cp /icenlp-web/dist/IceNLPWeb.war $CATALINA_HOME/webapps/
-
-ENTRYPOINT ./start.sh
+# Disable the default Tomcat webapps
+RUN rm -rf $CATALINA_HOME/webapps/*
+# and install ours
+COPY dist/IceNLPWeb.war $CATALINA_HOME/webapps/
 
 

--- a/build.xml
+++ b/build.xml
@@ -54,7 +54,7 @@
 
 	<target name="compile" depends="init" description="Compiles all the source files">
 		<!--<javac srcdir="${src}" destdir="${build}" classpath="${include}" /> -->
-        	<javac srcdir="${src}" destdir="${build}">
+        	<javac srcdir="${src}" destdir="${build}" source="1.8" target="1.8">
                   <classpath>
                     <path refid="mvn.compile.classpath" />
                     <fileset refid="include" />

--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<project name="IceNLPWeb" default="release-war" basedir=".">
+<project name="IceNLPWeb" default="release-war" basedir="." xmlns:maven="antlib:org.eclipse.aether.ant">
 	<description>
 		Compiles a release version of the IceNLP Web Project as a single jar file
 	</description>
@@ -10,16 +10,39 @@
 	<property name="dist" location="dist" />
 	<property name="lib" location="lib" />
 
-    <property name="include" location="${lib}/IceNLPCore.jar" />
-    <property name="j2ee" location="/opt/tomcat/tomcat/lib/servlet-api.jar" />
-    <property name="org.json" location="/opt/tomcat/tomcat/lib/json-20210307.jar" />
+    <fileset id="include" dir="${lib}" includes="*.jar"/>
     <!--property name="j2ee" location="/usr/java/lib/javaee-api-6.0.jar" /-->
 
     <property name="war_name" value="IceNLPWeb" />
     <property name="war_fullname" value="${war_name}.war" />
     <property name="war_fullpath" value="${dist}/${war_fullname}" />
 
-	<!--<property name="tomcat_path" value="/opt/tomcat/apache-tomcat-9.0.52/lib/servlet-api.jar" />-->
+	<!-- download a copy of aether ant tasks if we don't have them already
+		     NOTE: at some point switch to using Apache Maven Resolver for this -->
+	<get src="http://search.maven.org/remotecontent?filepath=org/eclipse/aether/aether-ant-tasks/1.0.0.v20140518/aether-ant-tasks-1.0.0.v20140518-uber.jar" dest="aether-ant-tasks-uber.jar" verbose="true" skipexisting="true" />
+	<fail message="Checksum mismatch for 'aether-ant-tasks-uber.jar'. Please delete it and rerun ant to redownload.">
+		<condition>
+			<not>
+				<checksum file="aether-ant-tasks-uber.jar" algorithm="SHA" property="95dadd03392a75564904da45108cf048abe6e5bb" verifyproperty="checksum.matches" />
+			</not>
+		</condition>
+	</fail>
+
+	<path id="aether-ant-tasks.classpath" path="aether-ant-tasks-uber.jar" />
+	<typedef resource="org/eclipse/aether/ant/antlib.xml" uri="antlib:org.eclipse.aether.ant" classpathref="aether-ant-tasks.classpath" />
+
+	<!-- build the classpath via maven -->
+	<maven:mirror id="central-https" url="https://repo1.maven.org/maven2" mirrorOf="central" />
+	<maven:resolve>
+		<maven:dependencies>
+			<maven:dependency groupid="javax.servlet" artifactid="javax.servlet-api" version="3.1.0" scope="provided" />
+			<maven:dependency groupid="eu.european-language-grid" artifactid="elg-java-bindings" version="1.0.0" />
+			<maven:dependency groupid="com.fasterxml.jackson.core" artifactid="jackson-databind" version="2.13.1" />
+			<maven:dependency groupid="com.fasterxml.jackson.core" artifactid="jackson-annotations" version="2.13.1" />
+		</maven:dependencies>
+		<path refid="mvn.compile.classpath" classpath="compile" />
+                <files refid="mvn.runtime.libs" classpath="runtime" />
+	</maven:resolve>
 
 	<target name="init" depends="clean">
 		<tstamp /> <!-- Create the timestamp for the build -->
@@ -31,7 +54,12 @@
 
 	<target name="compile" depends="init" description="Compiles all the source files">
 		<!--<javac srcdir="${src}" destdir="${build}" classpath="${include}" /> -->
-		<javac srcdir="${src}" destdir="${build}" classpath="${org.json};${include};${j2ee}" />
+        	<javac srcdir="${src}" destdir="${build}">
+                  <classpath>
+                    <path refid="mvn.compile.classpath" />
+                    <fileset refid="include" />
+                  </classpath>
+                </javac>
     	</target>
 
 
@@ -44,7 +72,14 @@
 			<!-- Copies files from the dict directory to the WEB-INF directory of the war file-->
 			<webinf dir="dict" includes="**/*.dict" />
             <!-- All files in the lib directory will end up in the WEB-INF/lib directory of the war file. -->
-            <lib dir="lib"/>
+            <lib refid="include"/>
+            <mappedresources>
+              <resources refid="mvn.runtime.libs" />
+              <chainedmapper>
+                <flattenmapper/>
+                <globmapper from="*" to="WEB-INF/lib/*"/>
+              </chainedmapper>
+            </mappedresources>
             <!-- All files in the META-INF directory will end up in the META-INF directory of the war file. -->
             <metainf dir="META-INF"/>
             <!-- All files in the build directory will end up in the WEB-INF/classes directory of the war file. -->

--- a/src/is/ru/cs/nlp/icenlp/web/IceNLPServlet.java
+++ b/src/is/ru/cs/nlp/icenlp/web/IceNLPServlet.java
@@ -154,10 +154,11 @@ public class IceNLPServlet extends HttpServlet
         return result;
     }
 
-    private void tokenize(String query, PrintWriter out, boolean english, boolean useStricktToken, int inputTokenizeType) throws IOException
+    private List<TextsResponse.Text> tokenize(String query, boolean english, boolean useStricktToken, int inputTokenizeType) throws IOException
     {
 
         Tokenizer tok = new Tokenizer(inputTokenizeType, useStricktToken, this.tokLex);
+		List<TextsResponse.Text> result = new ArrayList<>();
         segmentizer.segmentize(query);
         while(segmentizer.hasMoreSentences())
         {
@@ -168,10 +169,14 @@ public class IceNLPServlet extends HttpServlet
 
            tok.splitAbbreviations();
 
+		   List<TextsResponse.Text> tokensInSentence = new ArrayList<>();
            for(Object token : tok.tokens)
-             out.write("{" + ((TokenTags)token).lexeme + "}");
+             tokensInSentence.add(new TextsResponse.Text().withContent(((TokenTags)token).lexeme));
+
+			result.add(new TextsResponse.Text().withTexts(tokensInSentence).withRole("sentence"));
 
        }
+		return result;
     }
 
     @Override
@@ -282,10 +287,10 @@ public class IceNLPServlet extends HttpServlet
     {
 
         // Only show output of tokenization?
-//        if (showTokenization)
-//           tokenize(query, out, english, useStricktToken, inputTokenizeType);
-//        // else do both tagging and parsing
-//        else {
+        if (showTokenization)
+			return new TextsResponse().withTexts(tokenize(query, english, useStricktToken, inputTokenizeType));
+        // else do both tagging and parsing
+        else {
 
             // Tag
             long tagStart = System.currentTimeMillis();
@@ -309,7 +314,7 @@ public class IceNLPServlet extends HttpServlet
 
 	    //out.write(",\"parsed\":\"" + parsed.replaceAll( "\n", "|")+"\"");
 
-//	}
+		}
     }
 
     private boolean printWebError( PrintWriter out, String errorstring )

--- a/src/is/ru/cs/nlp/icenlp/web/IceNLPServlet.java
+++ b/src/is/ru/cs/nlp/icenlp/web/IceNLPServlet.java
@@ -259,7 +259,7 @@ public class IceNLPServlet extends HttpServlet
 		TextsResponse textsResponse = analyse(query, english, sentLine, markUnknown, functions, phraseLine, mergeLabels, featureAgreement, showErrors, modelType, showTokenization, strictTokenization, inputTokenizeType, showLemma);
 
 		response.setContentType("application/json");
-		mapper.writeValue(response.getOutputStream(), textsResponse);
+		mapper.writeValue(response.getOutputStream(), textsResponse.asMessage());
 	} catch (Exception e) {
 		e.printStackTrace();
 		response.setContentType("application/json");

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-# Recommend syntax for setting an infinite while loop
-
-$CATALINA_HOME/bin/startup.sh
-
-while :
-do
-    sleep 10
-done

--- a/test/basic.sh
+++ b/test/basic.sh
@@ -2,8 +2,8 @@
 
 #curl http://0.0.0.0:8080/IceNLPWeb/process -H 'Content-Type: application/json' -d '{"type":"text", "content":"hæ"}'
 
-LOC=/process/service
-#LOC=/IceNLPWeb/process
+#LOC=/process/service
+LOC=/IceNLPWeb/process
 
 curl http://0.0.0.0:8080$LOC -H 'Content-Type: application/json' -d '{"type":"text", "content":"hæ"}'
 echo


### PR DESCRIPTION
This PR includes a number of suggestions for improvements to the way icenlp uses ELG API formats.

- I've switched from generating the response JSON by hand as strings over to using the `elg-java-bindings` POJO classes created by the ELG project.  This will properly handle escaping of things like `"` and newline characters in the output.
- I've also changed it so that instead of a single flat list of tokens (all the sentences concatenated) the service now returns a list of sentences where each sentence is a list of tokens.
- Seeing as we have the `elg-java-bindings` I've used them for the request parsing as well.
- Errors are now returned with more appropriate ELG error codes, in particular request parsing errors generate an `elg.request.invalid` and errors during processing generate `elg.service.internalError`